### PR TITLE
Use world instance random over global random

### DIFF
--- a/worlds/sms/__init__.py
+++ b/worlds/sms/__init__.py
@@ -1,7 +1,7 @@
 """
 Archipelago init file for Super Mario Sunshine
 """
-import random, math
+import math
 from dataclasses import fields
 from typing import Dict, Any
 import os
@@ -64,7 +64,7 @@ class SmsWorld(World):
             self.options.start_inventory.value["Hover Nozzle"] = 1
 
         if self.options.level_access.value == 1:
-            pick = random.choice(list(TICKET_ITEMS.keys()))
+            pick = self.random.choice(list(TICKET_ITEMS.keys()))
             tick = str(pick)
             print(tick)
             self.options.start_inventory.value[tick] = 1


### PR DESCRIPTION
## What is this fixing or adding?
This PR removes use of the global `Random` instance and uses the instance attached to the `World` instead. This allows generations to be reproducible given the same seed.

## How was this tested?
I generated, it succeeded

## If this makes graphical changes, please attach screenshots.
N/A