### PR TITLE
Super Mario Sunshine: Fixed game-over deaths and deathlink duplicate during cutscenes

### DIFF
--- a/worlds/sms/SMSClient.py
+++ b/worlds/sms/SMSClient.py
@@ -49,8 +49,8 @@ world_flags = {}
 
 DEBUG = False
 GAME_VER = 0x3a
-AP_WORLD_VERSION_NAME = "0.6.5"
-CLIENT_VERSION = "0.5.3"
+AP_WORLD_VERSION_NAME = "0.6.7"
+CLIENT_VERSION = "0.6.2"
 
 DME_DOLPHIN_PROCESS_NAME_ENV_VARIABLE = "DME_DOLPHIN_PROCESS_NAME"
 
@@ -168,7 +168,7 @@ class SmsContext(SuperContext):
             temp = slot_data.get("starting_nozzle")
             if temp:
                 self.fludd_start = temp
-            temp = slot_data.get("ticket_mode")
+            temp = slot_data.get("level_access")
             if temp:
                 self.ticket_mode = temp
 
@@ -235,6 +235,7 @@ curNozzleBoxes = []
 
 DELAY_SECONDS = .5
 LOCATION_OFFSET = 523000
+GAME_OVER_LIFE_COUNT = 4294967295
 
 def read_string(console_address: int, strlen: int) -> str:
     return dme.read_bytes(console_address, strlen).split(b"\0", 1)[0].decode()
@@ -304,13 +305,14 @@ async def check_death(ctx: SmsContext, previous_lives):
 
     try:
         current_lives = get_lives()
-        if (current_lives < previous_lives != 4294967295) or (current_lives == 4294967295 and previous_lives == 0) and is_death_link_buffer() == False:
-            if not ctx.has_send_death and time.time() >= ctx.last_death_link + 6: #prevent more double-deaths
-                ctx.has_send_death = True
-                player_name = ctx.player_names[ctx.slot] if ctx.slot in ctx.player_names else "Player"
-                await ctx.send_death(f"{player_name} died!")
-                logger.info(f"Sent DeathLink: Mario died (lives {previous_lives} -> {current_lives})")
-                disable_death_link_buffer()
+        if (current_lives < previous_lives != GAME_OVER_LIFE_COUNT) or (current_lives == GAME_OVER_LIFE_COUNT and previous_lives == 0):
+            if not death_link_buffer_enabled():
+                if not ctx.has_send_death and time.time() >= ctx.last_death_link + 6: #prevent more double-deaths
+                    ctx.has_send_death = True
+                    player_name = ctx.player_names[ctx.slot] if ctx.slot in ctx.player_names else "Player"
+                    await ctx.send_death(f"{player_name} died!")
+                    logger.info(f"Sent DeathLink: Mario died (lives {previous_lives} -> {current_lives})")
+            disable_death_link_buffer()
         else:
             ctx.has_send_death = False
     except Exception as e:
@@ -684,7 +686,7 @@ def disable_death_link_buffer():
     global sms_death_link_buffer
     sms_death_link_buffer = False
 
-def is_death_link_buffer():
+def death_link_buffer_enabled():
     return sms_death_link_buffer
 
 def log_death_buffer_state():

--- a/worlds/sms/SMSClient.py
+++ b/worlds/sms/SMSClient.py
@@ -401,6 +401,9 @@ async def dolphin_sync_task(ctx: SmsContext) -> None:
                         ticket_list: set[str] = set([ctx.item_names.lookup_in_game(recv_item.item).replace(" Ticket", "")
                             for recv_item in ctx.items_received if ctx.item_names.lookup_in_game(recv_item.item) in TICKET_ITEMS])
                         ctx.ui.update_ticket_list(ticket_list)
+                        flag_pointer = dme.read_word(addresses.SMS_FLAGS_PTR)
+                        boat_and_yoshi_flags = dme.read_byte(flag_pointer + addresses.DELFINO_YOSHI_OFFSET)
+                        dme.write_byte(flag_pointer + addresses.DELFINO_YOSHI_OFFSET, boat_and_yoshi_flags | 0x02)
 
                 await asyncio.sleep(0.1)
             else:
@@ -535,13 +538,6 @@ def parse_bits(all_bits, ctx: SmsContext, parse_type: str):
                     logger.info("checks to send: %s", possible_locs[0])
         elif x == 119:
             send_victory(ctx)
-
-
-def get_shine_id(location, value):
-    temp = location + value - dme.read_word(addresses.SMS_FLAGS_PTR)
-    shine_id = int(temp)
-    return shine_id
-
 
 def refresh_item_count(ctx, item_id, targ_address):
     counts = collections.Counter(received_item.item for received_item in ctx.items_received)
@@ -717,6 +713,7 @@ async def resolve_tickets(stage, ctx):
             # Byte 1 should correspond to Delfino Plaza
             dme.write_byte(addresses.SMS_NEXT_STAGE, 1)
             dme.write_byte(addresses.SMS_CURRENT_STAGE, 1)
+            await send_map_id(1, ctx)
         else:
             await send_map_id(stage, ctx)
     return

--- a/worlds/sms/SMSClient.py
+++ b/worlds/sms/SMSClient.py
@@ -49,8 +49,8 @@ world_flags = {}
 
 DEBUG = False
 GAME_VER = 0x3a
-AP_WORLD_VERSION_NAME = "0.6.7"
-CLIENT_VERSION = "0.6.2"
+AP_WORLD_VERSION_NAME = "0.6.5"
+CLIENT_VERSION = "0.5.3"
 
 DME_DOLPHIN_PROCESS_NAME_ENV_VARIABLE = "DME_DOLPHIN_PROCESS_NAME"
 
@@ -168,7 +168,7 @@ class SmsContext(SuperContext):
             temp = slot_data.get("starting_nozzle")
             if temp:
                 self.fludd_start = temp
-            temp = slot_data.get("level_access")
+            temp = slot_data.get("ticket_mode")
             if temp:
                 self.ticket_mode = temp
 
@@ -275,7 +275,7 @@ async def game_watcher(ctx: SmsContext):
         if "DeathLink" in ctx.tags:
             await check_death(ctx, previous_lives)
             try:
-                previous_lives = dme.read_word(dme.read_word(addresses.SMS_FLAGS_PTR) + addresses.LIVES_COUNT_OFFSET)
+                previous_lives = get_lives()
             except:
                 pass
 
@@ -303,13 +303,14 @@ async def check_death(ctx: SmsContext, previous_lives):
         return
 
     try:
-        current_lives = dme.read_word(dme.read_word(addresses.SMS_FLAGS_PTR) + addresses.LIVES_COUNT_OFFSET)
-        if (current_lives < previous_lives != 255) or (current_lives == 0 and previous_lives == 255):
+        current_lives = get_lives()
+        if (current_lives < previous_lives != 4294967295) or (current_lives == 4294967295 and previous_lives == 0) and is_death_link_buffer() == False:
             if not ctx.has_send_death and time.time() >= ctx.last_death_link + 6: #prevent more double-deaths
                 ctx.has_send_death = True
                 player_name = ctx.player_names[ctx.slot] if ctx.slot in ctx.player_names else "Player"
                 await ctx.send_death(f"{player_name} died!")
                 logger.info(f"Sent DeathLink: Mario died (lives {previous_lives} -> {current_lives})")
+                disable_death_link_buffer()
         else:
             ctx.has_send_death = False
     except Exception as e:
@@ -398,9 +399,6 @@ async def dolphin_sync_task(ctx: SmsContext) -> None:
                         ticket_list: set[str] = set([ctx.item_names.lookup_in_game(recv_item.item).replace(" Ticket", "")
                             for recv_item in ctx.items_received if ctx.item_names.lookup_in_game(recv_item.item) in TICKET_ITEMS])
                         ctx.ui.update_ticket_list(ticket_list)
-                        flag_pointer = dme.read_word(addresses.SMS_FLAGS_PTR)
-                        boat_and_yoshi_flags = dme.read_byte(flag_pointer + addresses.DELFINO_YOSHI_OFFSET)
-                        dme.write_byte(flag_pointer + addresses.DELFINO_YOSHI_OFFSET, boat_and_yoshi_flags | 0x02)
 
                 await asyncio.sleep(0.1)
             else:
@@ -536,6 +534,13 @@ def parse_bits(all_bits, ctx: SmsContext, parse_type: str):
         elif x == 119:
             send_victory(ctx)
 
+
+def get_shine_id(location, value):
+    temp = location + value - dme.read_word(addresses.SMS_FLAGS_PTR)
+    shine_id = int(temp)
+    return shine_id
+
+
 def refresh_item_count(ctx, item_id, targ_address):
     counts = collections.Counter(received_item.item for received_item in ctx.items_received)
     temp = change_endian(counts[item_id])
@@ -669,6 +674,21 @@ def activate_yoshi(ctx):
         ctx.ap_nozzles_received.append(4)
     return
 
+sms_death_link_buffer = False
+
+def enable_death_link_buffer():
+    global sms_death_link_buffer
+    sms_death_link_buffer = True
+
+def disable_death_link_buffer():
+    global sms_death_link_buffer
+    sms_death_link_buffer = False
+
+def is_death_link_buffer():
+    return sms_death_link_buffer
+
+def log_death_buffer_state():
+    logger.info(f"Death Buffer state: {sms_death_link_buffer}")
 
 def kill_mario(ctx: SmsContext):
     """Uses the same logic as Gecko code death trigger"""
@@ -680,10 +700,13 @@ def kill_mario(ctx: SmsContext):
 
             dme.write_bytes(actual_target, (0x4020).to_bytes(2, byteorder="big"))
             ctx.has_send_death = True
+            enable_death_link_buffer()
         except Exception as e:
             logger.error(f"Failed to kill Mario - connection may be lost: {e}")
     return
 
+def get_lives():
+    return dme.read_word(dme.read_word(addresses.SMS_FLAGS_PTR) + addresses.LIVES_COUNT_OFFSET)
 
 async def resolve_tickets(stage, ctx):
     for tick in TICKETS:
@@ -692,7 +715,6 @@ async def resolve_tickets(stage, ctx):
             # Byte 1 should correspond to Delfino Plaza
             dme.write_byte(addresses.SMS_NEXT_STAGE, 1)
             dme.write_byte(addresses.SMS_CURRENT_STAGE, 1)
-            await send_map_id(1, ctx)
         else:
             await send_map_id(stage, ctx)
     return


### PR DESCRIPTION
## What is this fixing or adding?
This has 2 main fixes in it.
1. When Mario game overs, it will send out a death link when the player hits continue. This means that even if the player is killed via deathlink, this will send out a deathlink to all other players, essentially a "double-death"
2. When a deathlink is sent to mario during a cutscene (mainly during the shine get scene) the deathlink would get registered but then it would send out a duplicate deathlink which shouldn't have happened.

## How was this tested?
This was tested during an archipelago that was ran with Deathlink on with friends (needs a review from others before approval)