### PR TITLE
Added macOS support script and setup instructions to setup_en.md

### DIFF
--- a/worlds/sms/MacSetup.sh
+++ b/worlds/sms/MacSetup.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+dolphin="/Applications/Dolphin.app/Contents/MacOS/Dolphin"
+emphasis='\033[0;31m'
+
+function dolphin_sign
+{
+
+    echo "Signing Dolphin Emulator (usually necessary for new installs)"
+    printf "Skip? [y/N] "
+    read -r skip
+    case "$skip" in
+        n|N|"") ;;
+        *) return ;;
+    esac
+
+    printf "Enter location of Dolphin Emulator app (default=$dolphin): "
+    read -r dolphin_
+    if [ ! -z "$dolphin_" ]; then dolphin="$dolphin_"; fi
+
+    if [ ! -z "$(codesign -d --entitlements :- "$dolphin" 2> /dev/null | grep get-task-allow)" ]; then
+        echo "Dolphin is already re-signed!"
+        exit 0
+    fi
+
+    new_ent="$(mktemp)"
+    codesign -d --entitlements :- "$dolphin" 2> /dev/null | sed 's:</dict>:<key>com.apple.security.get-task-allow</key><true/></dict>:' > "$new_ent"
+    codesign --remove-signature "$dolphin"
+    if [ $? -ne 0 ]; then
+        echo "${emphasis}Dolphin signature could not be removed!\033[0m \n\033[1m** You may need to go to System Settings > Privacy & Security > App Management and enable the slider for 'Terminal'. **\033[0m"
+        exit 1
+    fi
+
+    codesign -s "$certificate" --entitlements "$new_ent" --deep "$dolphin"
+    if [ $? -ne 0 ]; then
+        echo "Dolphin could not be re-signed!"
+        exit 1
+    fi
+    echo "Success!"
+
+}
+
+printf "${emphasis}Ensure that you have created a code-signing certificate in the "System" keychain (instructions at https://sourceware.org/gdb/wiki/PermissionsDarwin#Create_a_certificate_in_the_System_Keychain).\033[0m\n"
+printf "Enter name of code-signing certificate: "
+read -r certificate
+if [ -z "$(security find-certificate -c "$certificate" | grep System)" ]; then
+    echo "That certificate could not be found in the System keychain!"
+    exit 1
+fi
+
+dolphin_sign
+
+echo
+echo "\033[1mIf macOS initially prevents Dolphin from starting, go to System Settings > Privacy & Security > Open Anyway (scroll to the bottom).\033[0m"

--- a/worlds/sms/docs/setup_en.md
+++ b/worlds/sms/docs/setup_en.md
@@ -9,6 +9,7 @@
 1. Download and install the latest release of Archipelago Multiworld from the link above.
 
 2. Download and install the latest release of Dolphin Emulator from the link above.
+   - If you are on macOS, follow the [macOS code signing requirements](#macos-code-signing-requirements) instructions below
 
 3. Download the APWorld from the [releases](https://github.com/Joshark/archipelago-sms/releases/latest) page and place it in your `custom_worlds` folder located in your Archipelago install director
 
@@ -65,3 +66,18 @@ If the game is being hosted on the Archipelago website download the patch file f
 ### Play the game
 
 Remember to be in the File Select screen **BEFORE** connecting in case of starting any new playthroughs as it might send unwanted checks if you connect while in a different save file
+
+## MacOS code signing
+To use Dolphin with Archipelago on macOS, the Dolphin Emulator executable must be signed with a valid certificate and entitlements so that it can be debugged. First, [create a code signing certificate](https://sourceware.org/gdb/wiki/PermissionsDarwin):
+
+> Open Keychain Access (/Applications/Utilities/Keychain Access.app)
+>
+> Open the menu item Keychain Access → Certificate Assistant → Create a Certificate...
+>
+> Choose a name, set Identity Type to Self Signed Root, set Certificate Type to Code Signing and select the Let me override defaults checkbox. Click several times on Continue until you get to the Specify a Location For The Certificate screen, then set Keychain to System.
+
+Then, run the interactive `MacSetup.sh` script inside the `worlds/sms` directory to re-sign Dolphin Emulator:
+
+    sh ./MacSetup.sh
+
+**Note that Dolphin must also be re-signed using this script after an update.**


### PR DESCRIPTION
## What is this fixing or adding?

Added the MacSetup.sh script from [Dolphin Memory Engine](https://github.com/aldelaro5/dolphin-memory-engine) and implementation instructions which adds full support for macOS.

## How was this tested?

Tested directly with @SomeJakeGuy on an M2 Mac mini with Archipelago 0.6.7 and Mario Sunshine AP v0.6.2. Client connects to Dolphin and sends checks as expected.