### PR TITLE
Fix ticket mode ignoring physical access (Pianta in logic issue)

### DIFF
--- a/worlds/sms/regions.py
+++ b/worlds/sms/regions.py
@@ -1,6 +1,5 @@
 from typing import TYPE_CHECKING
 
-from worlds.generic.Rules import add_rule
 from BaseClasses import Entrance, Region
 
 from .sms_regions.sms_region_helper import (
@@ -196,18 +195,12 @@ def create_region(region: SmsRegion, world: "SmsWorld"):
     ):
         new_entrance.requirements = []
 
-    # Require that the player has the ticket required for the region when ticket mode is enabled
+    # In ticket mode the ticket opens the stage door, but Mario still has to physically reach the
+    # entrance (e.g. Pianta Village's pipe needs the Rocket Nozzle), so the difficulty requirements
+    # are kept. The ticket itself is ANDed onto the entrance in create_sms_region_and_entrance_rules
+    # after the requirements are interpreted.
     if world.options.level_access.value == 1 and region.ticketed:
-        new_entrance.requirements = []
         curr_region.ticket_str = region.ticketed
-        add_rule(
-            new_entrance,
-            (
-                lambda state, ticket_str=region.ticketed: state.has(
-                    ticket_str, world.player
-                )
-            ),
-        )
 
     if (
         world.options.trade_shine_maximum.value == 0

--- a/worlds/sms/sms_regions/pianta_village.py
+++ b/worlds/sms/sms_regions/pianta_village.py
@@ -3,12 +3,23 @@ from .sms_region_helper import *
 # Pianta Village
 PIANTA_VILLAGE_ENTRANCE: SmsRegion = SmsRegion(
     SmsRegionName.PIANTA_ENTRANCE,
-    requirements=[Requirements([[NozzleType.rocket]])],
+    requirements=[Requirements([[NozzleType.rocket]]),
+        Requirements([[NozzleType.rocket]], skip_forward=True)],
     hard=[Requirements([[NozzleType.rocket]]), Requirements([[NozzleType.yoshi]], shines=5),
+        Requirements([[NozzleType.rocket]], skip_forward=True),
         Requirements([[NozzleType.yoshi]], skip_forward=True)],
     advanced=[Requirements([[NozzleType.rocket]]), Requirements([[NozzleType.yoshi]], shines=5),
-        Requirements([[NozzleType.yoshi]], skip_forward=True), Requirements([[NozzleType.hover]])],
-    tears=[Requirements()],
+        Requirements([[NozzleType.rocket]], skip_forward=True),
+        Requirements([[NozzleType.yoshi]], skip_forward=True),
+        Requirements([[NozzleType.hover]], skip_forward=True),
+        Requirements([[NozzleType.hover]])],
+    # The documented early-entry tricks need Hover at minimum. Item-less entry via infinite
+    # wall kicks is deliberately NOT in logic, even at salty_tears.
+    tears=[Requirements([[NozzleType.rocket]]), Requirements([[NozzleType.yoshi]], shines=5),
+        Requirements([[NozzleType.rocket]], skip_forward=True),
+        Requirements([[NozzleType.yoshi]], skip_forward=True),
+        Requirements([[NozzleType.hover]], skip_forward=True),
+        Requirements([[NozzleType.hover]])],
     ticketed="Pianta Village Ticket",
     parent_region=SmsRegionName.PLAZA,
 )

--- a/worlds/sms/sms_regions/sirena_beach.py
+++ b/worlds/sms/sms_regions/sirena_beach.py
@@ -3,9 +3,9 @@ from .sms_region_helper import *
 # Non-ticket requires yoshi to clear out the pineapple blocking the pipe. Ticket removes pineapple.
 SIRENA_BEACH_ENTRANCE: SmsRegion = SmsRegion(
     SmsRegionName.SIRENA_ENTRANCE,
-    requirements=[Requirements([[NozzleType.yoshi]], shines=5), Requirements([[NozzleType.yoshi]], skip_forward=True)],
+    requirements=[Requirements([[NozzleType.yoshi]], shines=5), Requirements([[NozzleType.yoshi]], skip_forward=True, fluddless_only=True)],
     hard=[],
-    advanced=[Requirements([[NozzleType.yoshi]], shines=5), Requirements([[NozzleType.yoshi]], skip_forward=True),
+    advanced=[Requirements([[NozzleType.yoshi]], shines=5), Requirements([[NozzleType.yoshi]], skip_forward=True, fluddless_only=True),
         Requirements([[NozzleType.hover]])],
     tears=[],
     ticketed="Sirena Beach Ticket",

--- a/worlds/sms/sms_regions/sms_region_helper.py
+++ b/worlds/sms/sms_regions/sms_region_helper.py
@@ -127,6 +127,8 @@ class Requirements(NamedTuple):
     manual_none: bool = (
         False  # Only matters for higher difficulties. Prevents fallback requirements.
     )
+    fluddless_only: bool = False  # skip_forward req that only applies in fluddless mode,
+    # for physical blockers the ticket itself removes in ticket mode (Sirena's pineapple).
 
     def is_empty(self):
         return (

--- a/worlds/sms/sms_rules.py
+++ b/worlds/sms/sms_rules.py
@@ -13,11 +13,23 @@ def interpret_requirements(
     spot: Entrance | SmsLocation,
     requirement_set: list[Requirements],
     world: "SmsWorld",
+    ticketed_entrance: bool = False,
 ) -> None:
     """Correctly applies and interprets custom requirements namedtuple for a given entrance/location."""
     # If a region/location does not have any items required, make the section(s) return no logic.
     if requirement_set is None or len(requirement_set) < 1:
         return
+
+    # A ticket opens the stage door, so on a ticketed level's entrance only the physical-access
+    # requirements (skip_forward) remain relevant — and not the ones whose blocker the ticket
+    # itself removes (fluddless_only). With none left the ticket alone gates the level.
+    if ticketed_entrance and world.options.level_access.value == 1:
+        requirement_set = [
+            phys_req for phys_req in requirement_set
+            if phys_req.skip_forward and not phys_req.fluddless_only
+        ]
+        if len(requirement_set) < 1:
+            return
 
     # If all shines are selectable, remove all the entrance requirements related to location access.
     # If a location has no reqs after that is removed, then it is considered empty and should be removed from the list.
@@ -151,7 +163,18 @@ def create_sms_region_and_entrance_rules(world: "SmsWorld"):
             for sms_entrance in sms_reg.entrances:
                 if hasattr(sms_entrance, "requirements"):
                     interpret_requirements(
-                        sms_entrance, sms_entrance.requirements, world
+                        sms_entrance, sms_entrance.requirements, world,
+                        ticketed_entrance=bool(getattr(sms_reg, "ticket_str", "")),
+                    )
+
+                # In ticket mode the ticket is required ON TOP of the physical access requirements
+                # interpreted above (a Pianta Village Ticket does not lift Mario up the cliff).
+                if world.options.level_access.value == 1 and getattr(sms_reg, "ticket_str", ""):
+                    add_rule(
+                        sms_entrance,
+                        (lambda state, ticket_str=sms_reg.ticket_str: state.has(
+                            ticket_str, world.player)),
+                        combine="and",
                     )
 
                 # If a parent region has any ticket str, get that ticket as well


### PR DESCRIPTION

## What is this fixing or adding?


In ticket mode, create_region replaced a ticketed level's entire entrance requirements with just the ticket. A ticket only sets the in-game stage unlock flag; Mario still has to physically reach the entrance, and the Pianta Village pipe needs the Rocket Nozzle (or the Yoshi/Hover tricks at higher difficulties). Since one random ticket is precollected and tickets can be placed anywhere, Pianta Village regularly entered logic in sphere 1 with no way up the cliff, at every difficulty (issue #64; reproduced in 23 of 60 ticket-mode seeds).

Pianta Village is the only level with a ticket-mode physical barrier: every other entrance is a walk-in once its stage flag is set, and Sirena's pineapple is removed by its ticket (issue #6, fixed in 0.5.0). So ticketed entrances now keep only their skip_forward (physical access) requirements in ticket mode, "ANDed" with the ticket, and requirements whose blocker the ticket removes are marked fluddless_only:

- regions.py: keep the difficulty requirements on ticketed entrances, only record the ticket
- sms_rules.py: in ticket mode reduce a ticketed entrance to its applicable skip_forward requirements (ticket-only when there are none, which preserves current behavior for the six other levels), then AND the ticket onto whatever remains
- sms_region_helper.py: new Requirements.fluddless_only flag
- sirena_beach.py: mark the Yoshi skip_forward requirement fluddless_only (pineapple still needs Yoshi in fluddless mode, not with a ticket)
- pianta_village.py: add Rocket skip_forward entries at every tier (and Hover at advanced+) so ticket and fluddless players get the same entry options as vanilla access, and give salty_tears the real requirements (no item-less entry exists; matches the entrance change on the episode_tracking&logic_fixes branch)


## How was this tested?

Verified: in ticket mode all seven levels remain reachable with ticket+spray only except Pianta Village (needs Rocket/Yoshi/Hover per difficulty), at all four difficulties; vanilla and fluddless entrance behavior unchanged; 60 vanilla + 60 ticket-mode generations with zero sphere violations.
